### PR TITLE
共通レイアウトのナビゲーションドロワーを追加

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -19,7 +19,7 @@ const Layout = ({children}: Props) => {
       <HStack alignItems="start">
         <Box 
           display={{ base: "none", md: "block" }} 
-          minW={200}
+          minW={180}
         >
           <Navigation />
         </Box>

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -12,14 +12,14 @@ const Layout = ({children}: Props) => {
     <>
       <Box display={{ base: "block", md: "none", }}>
         <ChakraUiDrawer>
-          <Navigation />
+          <Navigation smallDisplay={true} />
         </ChakraUiDrawer>
       </Box>
 
       <HStack alignItems="start">
         <Box 
           display={{ base: "none", md: "block" }} 
-          minW={240}
+          minW={200}
         >
           <Navigation />
         </Box>

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react';
+
+import Navigation from 'components/layouts/NavigationDrawer/Navigation'
+import ChakraUiDrawer from 'components/layouts/NavigationDrawer/Drawer'
+
+import { Box, HStack } from '@chakra-ui/react'
+
+type Props = { children: ReactNode }
+
+const Layout = ({children}: Props) => {
+  return (
+    <>
+      <Box display={{ base: "block", md: "none", }}>
+        <ChakraUiDrawer>
+          <Navigation />
+        </ChakraUiDrawer>
+      </Box>
+
+      <HStack alignItems="start">
+        <Box 
+          display={{ base: "none", md: "block" }} 
+          minW={240}
+        >
+          <Navigation />
+        </Box>
+        <Box>
+          {children}
+        </Box>
+      </HStack>
+    </>
+  )
+}
+
+export default Layout

--- a/src/components/layouts/NavigationDrawer/Drawer.tsx
+++ b/src/components/layouts/NavigationDrawer/Drawer.tsx
@@ -1,0 +1,39 @@
+import { ReactNode, useRef } from 'react';
+import { 
+  Drawer, 
+  DrawerContent, 
+  DrawerBody, 
+  useDisclosure,
+  Button 
+} from '@chakra-ui/react'
+
+type Props = { children: ReactNode }
+
+const ChakraUiDrawer = ({children}: Props) => {
+  const { isOpen, onClose, onOpen } = useDisclosure()
+  const btnRef = useRef(null)
+
+  return (
+    <>
+      <Button 
+        ref={btnRef} 
+        colorScheme='teal' 
+        onClick={onOpen}
+      >
+        Open
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        onClose={onClose}
+      >
+        <DrawerContent>
+          <DrawerBody>
+            {children}
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  )
+}
+
+export default ChakraUiDrawer

--- a/src/components/layouts/NavigationDrawer/Drawer.tsx
+++ b/src/components/layouts/NavigationDrawer/Drawer.tsx
@@ -6,7 +6,6 @@ import {
   DrawerOverlay,
   useDisclosure,
   Button,
-  Text
 } from '@chakra-ui/react'
 
 import { HamburgerIcon } from '@chakra-ui/icons'

--- a/src/components/layouts/NavigationDrawer/Drawer.tsx
+++ b/src/components/layouts/NavigationDrawer/Drawer.tsx
@@ -3,6 +3,7 @@ import {
   Drawer, 
   DrawerContent, 
   DrawerBody, 
+  DrawerOverlay,
   useDisclosure,
   Button 
 } from '@chakra-ui/react'
@@ -26,11 +27,14 @@ const ChakraUiDrawer = ({children}: Props) => {
         isOpen={isOpen}
         onClose={onClose}
       >
-        <DrawerContent>
+        <DrawerContent
+          background="chakra-body-bg"
+        >
           <DrawerBody>
             {children}
           </DrawerBody>
         </DrawerContent>
+        <DrawerOverlay />
       </Drawer>
     </>
   )

--- a/src/components/layouts/NavigationDrawer/Drawer.tsx
+++ b/src/components/layouts/NavigationDrawer/Drawer.tsx
@@ -5,8 +5,11 @@ import {
   DrawerBody, 
   DrawerOverlay,
   useDisclosure,
-  Button 
+  Button,
+  Text
 } from '@chakra-ui/react'
+
+import { HamburgerIcon } from '@chakra-ui/icons'
 
 type Props = { children: ReactNode }
 
@@ -18,14 +21,18 @@ const ChakraUiDrawer = ({children}: Props) => {
     <>
       <Button 
         ref={btnRef} 
-        colorScheme='teal' 
+        colorScheme='chakra-body-bg' 
         onClick={onOpen}
+        position="fixed"
+        bottom={3}
+        left={3}
       >
-        Open
+        <HamburgerIcon color="white" />
       </Button>
       <Drawer
         isOpen={isOpen}
         onClose={onClose}
+        placement="bottom"
       >
         <DrawerContent
           background="chakra-body-bg"

--- a/src/components/layouts/NavigationDrawer/Navigation.tsx
+++ b/src/components/layouts/NavigationDrawer/Navigation.tsx
@@ -26,6 +26,7 @@ const MenuButton = ({text, link, opacity}: MenuButtonProps) => {
       >
         <Text
           opacity={opacity}
+          fontSize='0.8rem'
         >
           {text}
         </Text>

--- a/src/components/layouts/NavigationDrawer/Navigation.tsx
+++ b/src/components/layouts/NavigationDrawer/Navigation.tsx
@@ -1,31 +1,68 @@
-import { Box, Text, VStack, Button } from '@chakra-ui/react'
+import NextLink from 'next/link'
+import { Link } from '@chakra-ui/react'
 
-const FullWidthButton = ({text} :{ text: string }) => {
+import { Text, VStack, Button } from '@chakra-ui/react'
+
+type MenuButtonProps = { 
+  text: string, 
+  link: string, 
+  opacity: number 
+}
+
+const MenuButton = ({text, link, opacity}: MenuButtonProps) => {
   return (
-    <Button 
-      w="100%"
-      borderRadius={0}
+    <Link 
+      href={link}
+      display="contents"
+      as={NextLink}
     >
-      <Text
-        opacity={0.3}
+      <Button 
+        w="100%"
+        h={12}
+        px={8}
+        borderRadius={0}
+        justifyContent="start"
+        background="chakra-body-bg"
       >
-        {text}
-      </Text>
-    </Button>
+        <Text
+          opacity={opacity}
+        >
+          {text}
+        </Text>
+      </Button>
+    </Link>
   )
 }
 
-const Navigation = () => {
+type Menu = {
+  route: string,
+  display: string
+}
+
+type NavigationMenuList = Menu[]
+
+const navigationMenuList = (): NavigationMenuList => {
+  return [
+    { route: '/', display: 'TOP' },
+    { route: '/ranking-japan-boxoffice2022', display: '2022年ランキング' }
+  ]
+}
+
+const Navigation = ({smallDisplay}: {smallDisplay?: boolean}) => {
   return (
     <VStack
-      py="8"
-      spacing="24px"
+      py="12"
     >
-      <FullWidthButton text={`ボタン`} />
-      <FullWidthButton text={`ボタン`} />
-      <FullWidthButton text={`ボタン`} />
-      <FullWidthButton text={`ボタン`} />
-      <FullWidthButton text={`ボタン`} />
+      {
+        navigationMenuList().map((menu, i) =>
+          <MenuButton 
+            key={i}
+            text={menu.display}
+            link={menu.route}
+            opacity={smallDisplay ? 0.8: 0.3}
+          />
+        )
+      }
     </VStack>
   )
 }

--- a/src/components/layouts/NavigationDrawer/Navigation.tsx
+++ b/src/components/layouts/NavigationDrawer/Navigation.tsx
@@ -1,0 +1,33 @@
+import { Box, Text, VStack, Button } from '@chakra-ui/react'
+
+const FullWidthButton = ({text} :{ text: string }) => {
+  return (
+    <Button 
+      w="100%"
+      borderRadius={0}
+    >
+      <Text
+        opacity={0.3}
+      >
+        {text}
+      </Text>
+    </Button>
+  )
+}
+
+const Navigation = () => {
+  return (
+    <VStack
+      py="8"
+      spacing="24px"
+    >
+      <FullWidthButton text={`ボタン`} />
+      <FullWidthButton text={`ボタン`} />
+      <FullWidthButton text={`ボタン`} />
+      <FullWidthButton text={`ボタン`} />
+      <FullWidthButton text={`ボタン`} />
+    </VStack>
+  )
+}
+
+export default Navigation

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sample-app",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.0.17",
         "@chakra-ui/react": "^2.5.1",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
@@ -444,6 +445,18 @@
       "integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.17.tgz",
+      "integrity": "sha512-HMJP0WrJgAmFR9+Xh/CBH0nVnGMsJ4ZC8MK6tMgxPKd9/muvn0I4hsicHqdPlLpmB0TlxlhkBAKaVMtOdz6F0w==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.0.16"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",

--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.0.17",
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,8 @@ import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
+import Layout from 'components/layouts/Layout'
+
 const theme = {
   config: {
     initialColorMode: 'dark',
@@ -14,7 +16,9 @@ export default function App({ Component, pageProps }: AppProps) {
     <ChakraProvider
       theme={extendTheme(theme)}
     >
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </ChakraProvider>
   )
 }


### PR DESCRIPTION
## 変更内容
全ページ共通のナビゲーションドロワーを追加しました。

## 仕様

- スマホ表示では左下のボタンで開閉
- PCでは常時表示

## 対応していないこと

- ランキング画面のスマホ表示をはじめ、スタイルを最適化していません。
（別ブランチにて対応済み）